### PR TITLE
Handle poe 3.29 character API mod objects

### DIFF
--- a/web/pobgen.py
+++ b/web/pobgen.py
@@ -189,6 +189,35 @@ def clean_name(name):
     return re.sub(r'\<\<set\:\w+\>\>', '', name)
 
 
+# The character API used to return every mod list as a list of strings, with
+# crafted, fractured and mutated mods split off into a `<flag>Mods` list each.
+# Since poe 3.29 it returns implicit/explicit mods as objects instead, and
+# folds those three lists back into `explicitMods`, tagged via `flags`:
+#   {"description": "+40 最大魔力", "flags": {"crafted": true}}
+# Some lists (`enchantMods`, ...) are still plain strings, so handle both.
+# See `ImportTab.lua:ImportItemsAndSkills` in PathOfBuilding, which reads the
+# same three flags and keeps the same three legacy lists, and `lineFlags` in
+# `Item.lua` for the prefixes its item text parser accepts.
+MOD_FLAG_PREFIXES = (
+    ('crafted', '{crafted}'),
+    ('fractured', '{fractured}'),
+    ('mutated', '{mutated}'),
+)
+
+
+def mod_description(mod):
+    if isinstance(mod, dict):
+        return mod['description']
+    return mod
+
+
+def mod_prefix(mod):
+    if not isinstance(mod, dict):
+        return ''
+    flags = mod.get('flags', {})
+    return ''.join(prefix for flag, prefix in MOD_FLAG_PREFIXES if flags.get(flag))
+
+
 # XXX since poe 3.8, category is removed
 # These are the categories that we are uncapable of handling at the moment
 CATEGORY_BLACKLIST = set('gems currency maps cards monsters leaguestones'.split())
@@ -312,6 +341,24 @@ class POBGenerator:
     def item_to_pob(self, item):
         return '\n'.join(self.i_item_to_pob(item))
 
+    def tr_mod_lines(self, mod, prefix):
+        """Translate one mod into the PoB item text lines it becomes.
+
+        POB tags mods per line -- `ImportTab.lua` splits every mod on newlines
+        before applying its flags -- and both the mod and its translation can
+        span several lines, so `prefix` goes on each of them.
+        """
+        description = mod_description(mod)
+        loc = description.find('\n附加的小型天賦給予：')
+        if loc != -1:
+            parts = (description[:loc], description[loc + 1 :])
+        else:
+            parts = (description,)
+        for part in parts:
+            for line in self.tr_mod(part).split('\n'):
+                if line:
+                    yield prefix + line
+
     def parse_magic(self, item):
         twbase = clean_name(item['typeLine']).rpartition('精良的 ')[-1]
         parts = re.findall('([^的之]+[的之]?)', twbase)
@@ -360,28 +407,31 @@ class POBGenerator:
             yield 'Sockets: ' + sockstr
         if item.get('corrupted'):
             yield 'Corrupted'
-        n_implicits = len(item.get('implicitMods', ())) + len(
-            item.get('enchantMods', ())
+        # `Implicits` counts lines, not mods: a mod whose translation spans
+        # several lines contributes one line each, so the lines have to be
+        # generated before the count can be emitted.
+        implicit_lines = list(
+            itertools.chain.from_iterable(
+                self.tr_mod_lines(mod, mod_prefix(mod))
+                for mod in itertools.chain(
+                    item.get('implicitMods', ()),
+                    item.get('enchantMods', ()),
+                )
+            )
         )
-        yield 'Implicits: {}'.format(n_implicits)
+        yield 'Implicits: {}'.format(len(implicit_lines))
         if item['name'] in ['禁忌烈焰', '禁忌血肉']:
             requiredClass = item['requirements'][0]['values'][0][0]
             yield 'Requires Class ' + CLASS_MAP[requiredClass]
-        for mod in itertools.chain(
-            item.get('implicitMods', ()),
-            item.get('enchantMods', ()),
-            item.get('explicitMods', ()),
-        ):
-            loc = mod.find('\n附加的小型天賦給予：')
-            if loc != -1:
-                yield self.tr_mod(mod[:loc])
-                yield self.tr_mod(mod[loc + 1 :])
-            else:
-                yield self.tr_mod(mod)
-        for cmod in item.get('craftedMods', ()):
-            yield '{crafted}' + self.tr_mod(cmod)
-        for fmod in item.get('fracturedMods', ()):
-            yield '{fractured}' + self.tr_mod(fmod)
+        for line in implicit_lines:
+            yield line
+        for mod in item.get('explicitMods', ()):
+            for line in self.tr_mod_lines(mod, mod_prefix(mod)):
+                yield line
+        for flag, prefix in MOD_FLAG_PREFIXES:
+            for mod in item.get('{}Mods'.format(flag), ()):
+                for line in self.tr_mod_lines(mod, prefix):
+                    yield line
         if item.get('shaper'):
             yield 'Shaper Item'
         if item.get('elder'):

--- a/web/tests/test_mods.py
+++ b/web/tests/test_mods.py
@@ -19,7 +19,10 @@ def test_roundtrip_1():
 
 
 def test_prev_failed():
-    assert tr('每顆暴擊球 +0.3% 暴擊率') == '+0.3% Critical Strike Chance per Power Charge'
+    assert (
+        tr('每顆暴擊球 +0.3% 暴擊率')
+        == '+0.3% to Critical Strike Chance per Power Charge'
+    )
     assert tr('增加 15% 地雷傷害') == '15% increased Mine Damage'
     assert (
         tr('0.27% 物理攻擊傷害偷取魔力') == '0.27% of Physical Attack Damage Leeched as Mana'

--- a/web/tests/test_pobgen.py
+++ b/web/tests/test_pobgen.py
@@ -1,0 +1,124 @@
+# -*- encoding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from pobgen import POBGenerator, mod_description, mod_prefix
+
+
+def test_mod_description_string():
+    assert mod_description('+40 最大魔力') == '+40 最大魔力'
+
+
+def test_mod_description_object():
+    assert mod_description({'description': '+40 最大魔力'}) == '+40 最大魔力'
+
+
+def test_mod_prefix_string():
+    assert mod_prefix('+40 最大魔力') == ''
+
+
+def test_mod_prefix_no_flags():
+    assert mod_prefix({'description': '+40 最大魔力'}) == ''
+
+
+def test_mod_prefix_crafted():
+    mod = {'description': '+40 最大魔力', 'flags': {'crafted': True}}
+    assert mod_prefix(mod) == '{crafted}'
+
+
+def test_mod_prefix_fractured():
+    mod = {'description': '+40 最大魔力', 'flags': {'fractured': True}}
+    assert mod_prefix(mod) == '{fractured}'
+
+
+def test_mod_prefix_mutated():
+    mod = {'description': '+40 最大魔力', 'flags': {'mutated': True}}
+    assert mod_prefix(mod) == '{mutated}'
+
+
+def item(**kwargs):
+    base = {
+        'frameType': 2,
+        'id': '0' * 64,
+        'name': '狂喜 護盔',
+        'typeLine': '全罩戰盔',
+        'ilvl': 82,
+    }
+    base.update(kwargs)
+    return base
+
+
+def pob_lines(**kwargs):
+    return POBGenerator().item_to_pob(item(**kwargs)).splitlines()
+
+
+def test_mods_as_strings():
+    """The pre-3.29 shape: mod lists are strings, flagged mods are separate."""
+    lines = pob_lines(
+        implicitMods=['+18 力量和敏捷'],
+        explicitMods=['+88 最大生命'],
+        craftedMods=['+40 最大魔力'],
+        fracturedMods=['+39 最大魔力'],
+        mutatedMods=['+37 最大魔力'],
+    )
+    assert lines[-5:] == [
+        '+18 to Strength and Dexterity',
+        '+88 to maximum Life',
+        '{crafted}+40 to maximum Mana',
+        '{fractured}+39 to maximum Mana',
+        '{mutated}+37 to maximum Mana',
+    ]
+
+
+def test_mods_as_objects():
+    """The current shape: mods are objects, flagged mods live in explicitMods."""
+    lines = pob_lines(
+        implicitMods=[{'description': '+18 力量和敏捷'}],
+        explicitMods=[
+            {'description': '+88 最大生命'},
+            {'description': '+40 最大魔力', 'flags': {'crafted': True}},
+            {'description': '+39 最大魔力', 'flags': {'fractured': True}},
+            {'description': '+37 最大魔力', 'flags': {'mutated': True}},
+        ],
+    )
+    assert lines[-5:] == [
+        '+18 to Strength and Dexterity',
+        '+88 to maximum Life',
+        '{crafted}+40 to maximum Mana',
+        '{fractured}+39 to maximum Mana',
+        '{mutated}+37 to maximum Mana',
+    ]
+
+
+def test_cluster_jewel_mod_as_object():
+    """The added-small-passives mod is split into two lines; both keep the prefix."""
+    mod = '增加 12% 傷害\n附加的小型天賦給予：增加 12% 傷害'
+    lines = pob_lines(explicitMods=[{'description': mod, 'flags': {'crafted': True}}])
+    assert lines[-2:] == [
+        '{crafted}12% increased Damage',
+        '{crafted}Added Small Passive Skills grant: 12% increased Damage',
+    ]
+
+
+def test_multiline_mod_prefixes_every_line():
+    """POB tags mods per line, so a multi-line mod needs the prefix on each."""
+    mod = '插槽中寶石沒有保留\n你的祝福技能失效'
+    lines = pob_lines(explicitMods=[{'description': mod, 'flags': {'fractured': True}}])
+    assert lines[-2:] == [
+        '{fractured}Socketed Gems have no Reservation',
+        '{fractured}Your Blessing Skills are Disabled',
+    ]
+
+
+def test_implicits_counts_lines_not_mods():
+    """`Implicits: n` is a line count: a two-line implicit counts as two."""
+    lines = pob_lines(
+        implicitMods=[{'description': '插槽中寶石沒有保留\n你的祝福技能失效'}],
+        explicitMods=[{'description': '+88 最大生命'}],
+    )
+    assert 'Implicits: 2' in lines
+    assert lines[-3:] == [
+        'Socketed Gems have no Reservation',
+        'Your Blessing Skills are Disabled',
+        '+88 to maximum Life',
+    ]


### PR DESCRIPTION
The character API now returns implicit and explicit mods as objects ({"description": ..., "flags": {...}}) instead of plain strings, and folds crafted, fractured and mutated mods into explicitMods instead of sending them as their own lists. Exporting any character failed with AttributeError: 'dict' object has no attribute 'find'.

Accept both shapes and take the {crafted}/{fractured}/{mutated} prefixes from flags, keeping the legacy per-flag lists as a fallback, matching what ImportTab.lua in PathOfBuilding does.

POB tags mods per line, so the prefix now goes on every line of a translated mod rather than only the first, and Implicits counts lines rather than mods for the same reason.